### PR TITLE
require spec helper before model

### DIFF
--- a/spec/models/condition_spec.rb
+++ b/spec/models/condition_spec.rb
@@ -1,5 +1,5 @@
-require './app/models/condition'
 require './spec/spec_helper'
+require './app/models/condition'
 
 RSpec.describe Condition do
   it('has data'){ expect(Condition.dashboard_data).to be_a(Hash) }


### PR DESCRIPTION
spec helper requires active record, it needs to go at the top